### PR TITLE
Update requests-cache to 0.9.7

### DIFF
--- a/dshelpers.py
+++ b/dshelpers.py
@@ -194,7 +194,7 @@ def _is_url_in_cache(*args, **kwargs):
     try:
         return requests_cache.get_cache().contains(key=request_hash)
     except AttributeError as e:  # requests_cache not enabled
-        if str(e) == "'Session' object has no attribute 'cache'":
+        if str(e) == "'NoneType' object has no attribute 'contains'":
             return False
         raise
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 
 pytest
 requests>=1.2.0
-requests-cache==0.5.2
+requests-cache>=0.9.7
 scraperwiki>=0.3.2


### PR DESCRIPTION
And fix the exception. Behaviour of `get_cache()` changed in 0.6.0:

https://github.com/requests-cache/requests-cache/commit/9822e3f55c40372c44ae4d8752e99e60ab88cbd4